### PR TITLE
[image_picker] remove photo authorization check for PHPickerViewController

### DIFF
--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   _pickerViewController = [[PHPickerViewController alloc] initWithConfiguration:config];
   _pickerViewController.delegate = self;
 
-  [self checkPhotoAuthorizationForAccessLevel];
+  [self showPhotoLibrary:PHPickerClassType];
 }
 
 - (void)pickImageWithUIImagePicker {


### PR DESCRIPTION
## Description

* remove photo authorization check for PHPickerViewController

https://developer.apple.com/videos/play/wwdc2020/10652/?time=70,
