### PR TITLE
[video_player - 1.0.1] some hls(m3u8) format video are not initializing on ios 15

### DIFF
--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -54,6 +54,8 @@ int64_t FLTCMTimeToMillis(CMTime time) {
 @end
 
 static void* timeRangeContext = &timeRangeContext;
+static void* presentationSizeContext = &presentationSizeContext;
+static void* durationContext = &durationContext;
 static void* statusContext = &statusContext;
 static void* playbackLikelyToKeepUpContext = &playbackLikelyToKeepUpContext;
 static void* playbackBufferEmptyContext = &playbackBufferEmptyContext;
@@ -74,6 +76,14 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
          forKeyPath:@"status"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:statusContext];
+  [item addObserver:self
+        forKeyPath:@"presentationSize"
+            options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+            context:presentationSizeContext];
+  [item addObserver:self
+        forKeyPath:@"duration"
+            options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+            context:durationContext];
   [item addObserver:self
          forKeyPath:@"playbackLikelyToKeepUp"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
@@ -268,10 +278,19 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         break;
       case AVPlayerItemStatusReadyToPlay:
         [item addOutput:_videoOutput];
-        [self sendInitialized];
+        [self setupEventSinkIfReadyToPlay];
         [self updatePlayingState];
         break;
     }
+  } else if (context == presentationSizeContext || context == durationContext) {
+      AVPlayerItem* item = (AVPlayerItem*)object;
+      if (item.status == AVPlayerItemStatusReadyToPlay) {
+        // Due to an apparent bug, when the player item is ready, it still may not have determined
+        // its presentation size or duration. When these properties are finally set, re-check if
+        // all required properties and instantiate the event sink if it is not already set up.
+        [self setupEventSinkIfReadyToPlay];
+        [self updatePlayingState];
+      }
   } else if (context == playbackLikelyToKeepUpContext) {
     if ([[_player currentItem] isPlaybackLikelyToKeepUp]) {
       [self updatePlayingState];
@@ -302,7 +321,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _displayLink.paused = !_isPlaying;
 }
 
-- (void)sendInitialized {
+- (void)setupEventSinkIfReadyToPlay {
   if (_eventSink && !_isInitialized) {
     CGSize size = [self.player currentItem].presentationSize;
     CGFloat width = size.width;
@@ -411,7 +430,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   // This line ensures the 'initialized' event is sent when the event
   // 'AVPlayerItemStatusReadyToPlay' fires before _eventSink is set (this function
   // onListenWithArguments is called)
-  [self sendInitialized];
+  [self setupEventSinkIfReadyToPlay];
   return nil;
 }
 


### PR DESCRIPTION
**What did you do**

- I've found that some of HLS video was not playing in iOS 15 here is the ticket link

**What was the issue and from where I got the solution**

- It looks like on iOS 15 AVPlayerItem.status is AVPlayerItemStatusReadyToPlay, but the presentationSize is zero.
So it falls through here, and there's never another attempt to initialize the video

**Github link:** 

Issue: https://github.com/flutter/flutter/issues/91975 
PR:  https://github.com/flutter/plugins/pull/4438/files

**How did you solve it?**

- Initialize player when size and duration become available on iOS

Fixes [FLTR-5949]

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested in real device and simulator it is working fine 

# Screenshot or Video

Screenshot Before | Screenshot After
------------------|------------------
<img width="588" alt="Screenshot 2021-11-02 at 11 04 12 AM" src="https://user-images.githubusercontent.com/55532492/139804418-1be69013-7173-447d-bf1c-10dddf4d229e.png">|<img width="588" alt="Screenshot 2021-11-02 at 10 15 59 AM" src="https://user-images.githubusercontent.com/55532492/139804454-35f3f01a-d328-40ad-9e1e-96ec1b6ecb25.png">




[FLTR-5949]: https://insight-timer.atlassian.net/browse/FLTR-5949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ