### PR TITLE
FLTR-9384: Fixed crash when cancelling app store sign in.

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase/ios/Classes/FIAObjectTranslator.m
@@ -162,6 +162,16 @@
       userInfo[key] = [FIAObjectTranslator getMapFromNSError:value];
     } else if ([value isKindOfClass:[NSURL class]]) {
       userInfo[key] = [value absoluteString];
+    } else if ([value isKindOfClass:[NSArray class]]) {
+        NSMutableArray *convertArr = @[].mutableCopy;
+        for (id item in value) {
+            if ([item isKindOfClass:[NSError class]]) {
+                [convertArr addObject:[FIAObjectTranslator getMapFromNSError:item]];
+            } else {
+                [convertArr addObject:item];
+            }
+        }
+      userInfo[key] = convertArr;
     } else {
       userInfo[key] = value;
     }


### PR DESCRIPTION
This PR fixed the crash on iOS 15.4 and above, due to the iOS implementation try to encoded an `NSError` object.

This PR cannot and should be merged, because the modified file has been removed in the latest version.